### PR TITLE
Changed: Refactor workflow to test local action instead of published version

### DIFF
--- a/.github/workflows/test-mkdocs-workflow.yml
+++ b/.github/workflows/test-mkdocs-workflow.yml
@@ -4,13 +4,6 @@ on:
   schedule:
     - cron: '0 0 * * *' # Run daily at midnight
   workflow_dispatch:
-  push:
-    branches: [ v1-master ]
-    tags:
-      - 'v1'
-    paths:
-      - 'action.yml'
-      - '.github/workflows/test-mkdocs-workflow.yml'
   pull_request:
     branches: [ v1-master ]
     paths:
@@ -24,14 +17,19 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout Action Repository
+        uses: actions/checkout@v4
       - name: Checkout Test Repository
         uses: actions/checkout@v4
         with:
           repository: Reloaded-Project/Reloaded.MkDocsMaterial.Themes.R2
           submodules: 'recursive'
+          path: test-project
       - name: Test Default Parameters
-        uses: Reloaded-Project/devops-mkdocs@v1
+        uses: ./
         with:
+          config-file: test-project/mkdocs.yml
+          requirements: test-project/docs/requirements.txt
           checkout-current-repo: false
           publish-to-pages: false
 
@@ -41,14 +39,19 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout Action Repository
+        uses: actions/checkout@v4
       - name: Checkout Test Repository
         uses: actions/checkout@v4
         with:
           repository: Reloaded-Project/Reloaded.MkDocsMaterial.Themes.R2
           submodules: 'recursive'
+          path: test-project
       - name: Test Custom MkDocs Version
-        uses: Reloaded-Project/devops-mkdocs@v1
+        uses: ./
         with:
+          config-file: test-project/mkdocs.yml
+          requirements: test-project/docs/requirements.txt
           mkdocs-version: '9.5.24'
           checkout-current-repo: false
           publish-to-pages: false
@@ -59,14 +62,19 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout Action Repository
+        uses: actions/checkout@v4
       - name: Checkout Test Repository
         uses: actions/checkout@v4
         with:
           repository: Reloaded-Project/Reloaded.MkDocsMaterial.Themes.R2
           submodules: 'recursive'
+          path: test-project
       - name: Test Custom Pre-build Command (Bash)
-        uses: Reloaded-Project/devops-mkdocs@v1
+        uses: ./
         with:
+          config-file: test-project/mkdocs.yml
+          requirements: test-project/docs/requirements.txt
           pre-build-command: touch pre-build-bash-executed.txt
           pre-build-command-shell: bash
           checkout-current-repo: false
@@ -85,14 +93,19 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout Action Repository
+        uses: actions/checkout@v4
       - name: Checkout Test Repository
         uses: actions/checkout@v4
         with:
           repository: Reloaded-Project/Reloaded.MkDocsMaterial.Themes.R2
           submodules: 'recursive'
+          path: test-project
       - name: Test Custom Pre-build Command (PowerShell)
-        uses: Reloaded-Project/devops-mkdocs@v1
+        uses: ./
         with:
+          config-file: test-project/mkdocs.yml
+          requirements: test-project/docs/requirements.txt
           pre-build-command: New-Item -ItemType File -Path pre-build-pwsh-executed.txt
           pre-build-command-shell: pwsh
           checkout-current-repo: false
@@ -111,14 +124,19 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout Action Repository
+        uses: actions/checkout@v4
       - name: Checkout Test Repository
         uses: actions/checkout@v4
         with:
           repository: Reloaded-Project/Reloaded.MkDocsMaterial.Themes.R2
           submodules: 'recursive'
+          path: test-project
       - name: Test Custom Output Directory
-        uses: Reloaded-Project/devops-mkdocs@v1
+        uses: ./
         with:
+          config-file: test-project/mkdocs.yml
+          requirements: test-project/docs/requirements.txt
           output-directory: custom_site_dir
           checkout-current-repo: false
           publish-to-pages: false
@@ -136,18 +154,22 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout Action Repository
+        uses: actions/checkout@v4
       - name: Checkout Test Repository
         uses: actions/checkout@v4
         with:
           repository: Reloaded-Project/Reloaded.MkDocsMaterial.Themes.R2
           submodules: 'recursive'
+          path: test-project
       - name: Copy Custom Requirements File
         shell: bash
-        run: cp docs/requirements.txt docs/custom-requirements.txt
+        run: cp test-project/docs/requirements.txt test-project/docs/custom-requirements.txt
       - name: Test Custom Requirements Path
-        uses: Reloaded-Project/devops-mkdocs@v1
+        uses: ./
         with:
-          requirements: docs/custom-requirements.txt
+          config-file: test-project/mkdocs.yml
+          requirements: test-project/docs/custom-requirements.txt
           checkout-current-repo: false
           publish-to-pages: false
 
@@ -157,18 +179,22 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout Action Repository
+        uses: actions/checkout@v4
       - name: Checkout Test Repository
         uses: actions/checkout@v4
         with:
           repository: Reloaded-Project/Reloaded.MkDocsMaterial.Themes.R2
           submodules: 'recursive'
+          path: test-project
       - name: Copy Custom Config File
         shell: bash
-        run: cp mkdocs.yml custom-mkdocs.yml
+        run: cp test-project/mkdocs.yml test-project/custom-mkdocs.yml
       - name: Test Custom Config File
-        uses: Reloaded-Project/devops-mkdocs@v1
+        uses: ./
         with:
-          config-file: custom-mkdocs.yml
+          config-file: test-project/custom-mkdocs.yml
+          requirements: test-project/docs/requirements.txt
           checkout-current-repo: false
           publish-to-pages: false
 
@@ -180,13 +206,18 @@ jobs:
       pages: write
       id-token: write
     steps:
+      - name: Checkout Action Repository
+        uses: actions/checkout@v4
       - name: Checkout Test Repository
         uses: actions/checkout@v4
         with:
           repository: Reloaded-Project/Reloaded.MkDocsMaterial.Themes.R2
           submodules: 'recursive'
+          path: test-project
       - name: Test Publish to Pages
-        uses: Reloaded-Project/devops-mkdocs@v1
+        uses: ./
         with:
+          config-file: test-project/mkdocs.yml
+          requirements: test-project/docs/requirements.txt
           publish-to-pages: true
           checkout-current-repo: false

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 name: Build and Deploy MkDocs Material (Reloaded)
 description: Builds and/or Deploys MkDocs Material to GitHub Pages, or a Directory
 branding:
-  icon: 'book'
-  color: 'red'
+  icon: "book"
+  color: "red"
 
 inputs:
   mkdocs-version:
@@ -83,7 +83,15 @@ runs:
 
     - name: Build MkDocs Site
       shell: bash
-      run: mkdocs build --config-file "${{ inputs.config-file }}" --site-dir "${{ inputs.output-directory }}"
+      run: |
+        # Build to temp location (mkdocs interprets --site-dir relative to config file)
+        CONFIG_DIR=$(dirname "${{ inputs.config-file }}")
+        TEMP_DIR="${CONFIG_DIR}/.mkdocs-build-temp"
+        rm -rf "$TEMP_DIR"
+        mkdocs build --config-file "${{ inputs.config-file }}" --site-dir ".mkdocs-build-temp"
+        # Move to user's desired output directory (relative to workspace root)
+        rm -rf "${{ inputs.output-directory }}"
+        mv "$TEMP_DIR" "${{ inputs.output-directory }}"
 
     - name: Upload pages artifact
       if: ${{ inputs.publish-to-pages == 'true' }}


### PR DESCRIPTION
- Removed push trigger (v1 tags and branch pushes)
- Restructured all 8 jobs with dual-checkout pattern (action repo + test project)
- Changed action reference from Reloaded-Project/devops-mkdocs@v1 to local ./
- Updated all jobs to specify config-file path in test-project directory
- Fixed path references in custom requirements and config file tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated testing workflow to consistently prepare test artifacts before each job, improving reliability across scenarios.
  * Switched tests to run using a local workflow action with explicit configuration and requirements parameters for predictable behavior.
  * Standardized checkout and configuration handling across all test variants to ensure uniform test execution.
  * Adjusted site build output handling to build to a temporary location before moving to the final output directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->